### PR TITLE
Bug Fix to BiocInstaller

### DIFF
--- a/R/lift.R
+++ b/R/lift.R
@@ -116,7 +116,7 @@ lift = function(
 
   # factory packages
   liftr_factory = quote_str(c(
-    'devtools', 'knitr', 'rmarkdown', 'shiny', 'RCurl'))
+    'devtools', 'BiocManager','knitr', 'rmarkdown', 'shiny', 'RCurl'))
 
   # write output files
   if (is.null(output_dir)) output_dir = file_dir(input)

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -67,7 +67,9 @@ parse_cran = function(cran) {
 
 parse_bioc = function(bioc) {
   if (!is.null(bioc)) {
-    liftr_bioc = quote_str(bioc)
+    liftr_bioc_version = gsub('.*\\/(.*)', '\\1', bioc)
+    bioc_package<- gsub('(.*)\\/.*', '\\1', bioc)
+    liftr_bioc = quote_str(bioc_package)
     tmp = tempfile()
     invisible(knit(
       input = system.file(
@@ -79,6 +81,7 @@ parse_bioc = function(bioc) {
     NULL
   }
 }
+
 
 parse_remotes = function(remotes) {
   if (!is.null(remotes)) {

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -67,7 +67,7 @@ parse_cran = function(cran) {
 
 parse_bioc = function(bioc) {
   if (!is.null(bioc)) {
-    liftr_bioc_version = gsub('.*\\/(.*)', '\\1', bioc)
+    liftr_bioc_version = gsub('.*\\/(.*)', '\\1', bioc[1])
     bioc_package<- gsub('(.*)\\/.*', '\\1', bioc)
     liftr_bioc = quote_str(bioc_package)
     tmp = tempfile()

--- a/inst/examples/bioc-rnaseq.Rmd
+++ b/inst/examples/bioc-rnaseq.Rmd
@@ -27,7 +27,7 @@ liftr:
     - PoiClaClu
     - ggbeeswarm
   bioc:
-    - BiocStyle
+    - BiocStyle/3.9
     - airway
     - Rsamtools
     - GenomicFeatures

--- a/inst/templates/pkg-bioc.Rmd
+++ b/inst/templates/pkg-bioc.Rmd
@@ -1,1 +1,1 @@
-RUN Rscript -e "source('http://bioconductor.org/biocLite.R');biocLite(c(`r liftr_bioc`))"
+RUN Rscript -e "BiocManager::install(c(`r liftr_bioc`), version = `r liftr_bioc_version`)"

--- a/vignettes/liftr-intro.Rmd
+++ b/vignettes/liftr-intro.Rmd
@@ -40,7 +40,7 @@ liftr:
   cran:
     - glmnet
   bioc:
-    - Gviz
+    - Gviz/3.9
   remotes:
     - "nanxstats/liftr"
   include: "DockerfileSnippet"
@@ -106,6 +106,8 @@ All available metadata fields are expained below.
 - `bioc`
 
     Bioconductor packages depended in the document.
+    If used, first package must be followed by desired Bioconductor version (e.g. `Gviz/3.9`).
+    All the packages used must be installed from the same Bioconductor version. 
 
 - `remotes`
 


### PR DESCRIPTION
It is a quick bug fix for the BiocInstaller situation. 

Modifications in the parsers. 

Main usage modification:

    Bioconductor packages depended in the document.
    If used, first package must be followed by desired Bioconductor version (e.g. `Gviz/3.9`).
    All the packages used must be installed from the same Bioconductor version. 

It was the work around I could build with the time I had. 
I hope it helps :) 

